### PR TITLE
Fixed link to demo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can change the behavior of these functions by defining them **_before_** you
 
 # Demo
 
-Sure. Feel free [to take a look](https://julianxhokaxhiu.github.io/iframe-position-fixed-polyfill/)
+Sure. Feel free [to take a look](https://mercedesbenzio.github.io/iframe-position-fixed-polyfill/)
 
 # License
 


### PR DESCRIPTION
The link to the demo seemed to be wrong (error 404), changed to the one from the repo description.